### PR TITLE
List the dependencies of the image in pkglist

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -4,11 +4,11 @@ on:
   schedule:
   - cron: "0 8 * * 3"
 
-  push:
-    paths:
-      - .github/workflows/versions.yml
-      - provision/pkglist
-      - tools/apt.bash
+  # push:
+  #   paths:
+  #     - .github/workflows/versions.yml
+  #     - provision/pkglist
+  #     - tools/apt.bash
 
 jobs:
   apt-get:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ARG VERSION=1.77
 
+COPY provision/pkglist /cardboardci/pkglist
+RUN apt-get update \
+    && xargs -a /cardboardci/pkglist apt-get install --no-install-recommends -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY provision/install.sh /tmp/install.sh
 RUN bash /tmp/install.sh ; sync ; rm /tmp/install.sh
 

--- a/provision/install.sh
+++ b/provision/install.sh
@@ -1,13 +1,8 @@
 #!/bin/sh
-apt-get update
-apt-get install -y build-essential libpcre3-dev curl python python-pygments
-apt-get clean
-rm -rf /var/lib/apt/lists/*
+mkdir /cfg
 
-mkdir /cfg 
-
-cd /tmp \
-curl -L https://github.com/danmar/cppcheck/archive/${VERSION}.tar.gz | tar xz
+cd /tmp
+curl -sSL https://github.com/danmar/cppcheck/archive/${VERSION}.tar.gz | tar xz
 cd cppcheck-${VERSION}
 SRCDIR=build CFGDIR=/cfg HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function" make
 SRCDIR=build CFGDIR=/cfg HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function" make install

--- a/provision/pkglist
+++ b/provision/pkglist
@@ -1,5 +1,5 @@
-build-essential=1
-libpcre3-dev=1
-curl=1
-python=1
-python-pygments=1
+build-essential=12.8ubuntu1
+libpcre3-dev=2:8.39-12
+curl=7.66.0-1ubuntu1
+python=2.7.17-1
+python-pygments=2.3.1+dfsg-1ubuntu2

--- a/provision/pkglist
+++ b/provision/pkglist
@@ -1,0 +1,5 @@
+build-essential=1
+libpcre3-dev=1
+curl=1
+python=1
+python-pygments=1


### PR DESCRIPTION
This should have been done before merging in the work for #8, but bulk changes are always fun.

This PR lists all of the dependencies of the image in the pkglist file. Additionally it disables the run-on-push trigger of the versions script.